### PR TITLE
Adjust sytem headers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "libcxx"]
 	path = libcxx
 	url = https://github.com/CTSRD-CHERI/libcxx.git
+[submodule "mbedtls"]
+	path = mbedtls
+	url = https://github.com/ARMmbed/mbedtls.git

--- a/boot/src/boot/boot_utils.c
+++ b/boot/src/boot/boot_utils.c
@@ -37,6 +37,7 @@
 #include "boot/boot_info.h"
 #include "object.h"
 #include "string.h"
+#include "strings.h"
 #include "uart.h"
 #include "elf.h"
 #include "utils.h"

--- a/cherios/core/memmgt/src/mmap.c
+++ b/cherios/core/memmgt/src/mmap.c
@@ -40,6 +40,7 @@
 #include "syscalls.h"
 #include "stdio.h"
 #include "string.h"
+#include "strings.h"
 #include "pmem.h"
 
 

--- a/cherios/core/memmgt/src/pmem.c
+++ b/cherios/core/memmgt/src/pmem.c
@@ -39,6 +39,7 @@
 #include "mmap.h"
 #include "math.h"
 #include "object.h"
+#include "strings.h"
 
 page_t* book;
 

--- a/cherios/core/namespace/src/namespace.c
+++ b/cherios/core/namespace/src/namespace.c
@@ -37,6 +37,7 @@
 #include "stdio.h"
 #include "string.h"
 #include "crt.h"
+#include "strings.h"
 
 typedef struct {
 	void * act_reference;

--- a/cherios/kernel/include/klib.h
+++ b/cherios/kernel/include/klib.h
@@ -43,6 +43,7 @@
 #include "math.h"
 #include "sched.h"
 #include "string.h"
+#include "strings.h"
 #include "kutils.h"
 #include "syscalls.h"
 

--- a/cherios/system/dylink/src/client.c
+++ b/cherios/system/dylink/src/client.c
@@ -42,6 +42,7 @@
 #include "misc.h"
 #include "namespace.h"
 #include "macroutils.h"
+#include "strings.h"
 
 // We batch symbol exchnage because otherwise there would be far too many domain crossings
 #define SYMBOL_EXCHANGE_MAX 0x20

--- a/cherios/system/libsocket/src/sockets.c
+++ b/cherios/system/libsocket/src/sockets.c
@@ -32,6 +32,7 @@
 #include <queue.h>
 #include "object.h"
 #include "string.h"
+#include "strings.h"
 #include "nano/nanokernel.h"
 #include "assert.h"
 #include "cheric.h"

--- a/cherios/system/lwip/src/main.c
+++ b/cherios/system/lwip/src/main.c
@@ -33,6 +33,7 @@
 #include "cheristd.h"
 #include "cheric.h"
 #include "stdlib.h"
+#include "strings.h"
 #include "assert.h"
 #include "mman.h"
 #include "misc.h"

--- a/cherios/system/lwip/src/virtio/virtio_driver.c
+++ b/cherios/system/lwip/src/virtio/virtio_driver.c
@@ -31,6 +31,7 @@
 #include "lwip_driver.h"
 #include "mman.h"
 #include "malta_virtio_mmio.h"
+#include "strings.h"
 
 static void alloc_recv(net_session* session) {
 

--- a/cherios/system/type_manager/src/main.c
+++ b/cherios/system/type_manager/src/main.c
@@ -33,6 +33,7 @@
 #include "stdlib.h"
 #include "lists.h"
 #include "string.h"
+#include "strings.h"
 #include "type_manager.h"
 #include "misc.h"
 #include "namespace.h"

--- a/churn/src/main.c
+++ b/churn/src/main.c
@@ -31,6 +31,7 @@
 #include "cheric.h"
 #include "mman.h"
 #include "string.h"
+#include "strings.h"
 #include "assert.h"
 #include "stdio.h"
 #include "syscalls.h"

--- a/elf/src/cprogram.c
+++ b/elf/src/cprogram.c
@@ -32,6 +32,7 @@
 #include "cprogram.h"
 #include "queue.h"
 #include "string.h"
+#include "strings.h"
 #include "syscalls.h"
 #include "mman.h"
 #include "assert.h"

--- a/elf/src/elf_loader.c
+++ b/elf/src/elf_loader.c
@@ -45,6 +45,7 @@
 #include "cheric.h"
 #include "math.h"
 #include "string.h"
+#include "strings.h"
 #include "elf.h"
 #include "nano/nanokernel.h"
 #include "mman.h"

--- a/fs_test/src/main.c
+++ b/fs_test/src/main.c
@@ -34,6 +34,7 @@
 #include "assert.h"
 #include "stdio.h"
 #include "string.h"
+#include "strings.h"
 #include "aes.h"
 
 #define BIG_SIZE 0x1000

--- a/include/atomic.h
+++ b/include/atomic.h
@@ -40,7 +40,7 @@ __asm__ __volatile__ (                              \
     SANE_ASM                                        \
     "1:"                                            \
     LOADL(type) "    %[out], %[ptr]          \n"    \
-    ADD(type, val_type)" %[add], %[out], %[v]      \n"    \
+    ASM_ADD(type, val_type)" %[add], %[out], %[v]      \n"    \
     STOREC(type) "   %[tmp], %[add], %[ptr]  \n"    \
     "beqz           %[tmp], 1b              \n"     \
     "nop                                    \n"     \

--- a/include/cheric.h
+++ b/include/cheric.h
@@ -118,17 +118,17 @@ static inline precision_rounded_length round_cheri_length(size_t length) {
 #define OUT_32i  "i"
 #define OUT_64i  "i"
 
-#define ADD_8_16i	"daddiu"
-#define ADD_16_16i	"daddiu"
-#define ADD_32_16i	"daddiu"
-#define ADD_64_16i	"daddiu"
-#define ADD_c_16i	"cincoffset"
+#define ASM_ADD_8_16i	"daddiu"
+#define ASM_ADD_16_16i	"daddiu"
+#define ASM_ADD_32_16i	"daddiu"
+#define ASM_ADD_64_16i	"daddiu"
+#define ASM_ADD_c_16i	"cincoffset"
 
-#define ADD_8_64	"daddu"
-#define ADD_16_64	"daddu"
-#define ADD_32_64	"daddu"
-#define ADD_64_64	"daddu"
-#define ADD_c_64	"cincoffset"
+#define ASM_ADD_8_64	"daddu"
+#define ASM_ADD_16_64	"daddu"
+#define ASM_ADD_32_64	"daddu"
+#define ASM_ADD_64_64	"daddu"
+#define ASM_ADD_c_64	"cincoffset"
 
 #define CTYPE_8 uint8_t
 #define CTYPE_16	uint16_t
@@ -145,7 +145,7 @@ static inline precision_rounded_length round_cheri_length(size_t length) {
 
 #define BNE(type, a, b, label,tmp) BNE_ ## type(a,b,label,tmp)
 
-#define ADD(type, val_type) ADD_ ## type ## _ ## val_type
+#define ASM_ADD(type, val_type) ASM_ADD_ ## type ## _ ## val_type
 
 #define LOADL(type)  "cll" SUF_ ## type
 #define LOAD(type) "cl" SUF_ ## type

--- a/include/mips.h
+++ b/include/mips.h
@@ -79,6 +79,8 @@
 
 #ifndef __ASSEMBLY__
 
+#include <stdint.h>
+
 /*
  * Provide more convenient names for useful qualifiers from gcc/clang.
  */
@@ -96,55 +98,6 @@ typedef long		ssize_t;
 typedef	unsigned long	size_t;
 
 typedef long		off_t;
-
-/*
- * Useful integer type names that we can't pick up from the compile-time
- * environment.
- */
-typedef char		int8_t;
-typedef unsigned char	u_char;
-typedef unsigned char	uint8_t;
-typedef short		int16_t;
-typedef unsigned short	u_short;
-typedef unsigned short	uint16_t;
-typedef int		int32_t;
-typedef unsigned int	u_int;
-typedef unsigned int	uint32_t;
-typedef long		intmax_t;
-typedef long		quad_t;
-typedef long		ptrdiff_t;
-typedef long		int64_t;
-typedef unsigned long	u_long;
-typedef unsigned long	uint64_t;
-typedef	unsigned long	uintmax_t;
-typedef unsigned long	u_quad_t;
-typedef __uintcap_t	uintptr_t;
-//typedef unsigned long	uintptr_t;
-typedef __intcap_t	intptr_t;
-typedef unsigned long	caddr_t;
-
-typedef u_long		ulong;
-typedef u_char		uchar;
-typedef uint8_t		u8;
-typedef uint16_t	u16;
-typedef uint32_t	u32;
-typedef uint64_t	u64;
-typedef uint16_t	__u16;
-typedef uint32_t	__u32;
-typedef uint8_t		u_int8_t;
-typedef uint16_t	u_int16_t;
-typedef uint32_t	u_int32_t;
-typedef uint64_t	u_int64_t;
-
-#define define_intypes(size)                                \
-typedef int ## size ## _t  int_least ## size ## _t;         \
-typedef uint ## size ## _t  uint_least ## size ## _t;       \
-typedef int ## size ## _t  int_fast ## size ## _t;          \
-typedef uint ## size ## _t  uint_fast ## size ## _t;
-
-#define INT_SIZES(ITEM) ITEM(8) ITEM(16) ITEM(32) ITEM(64)
-
-INT_SIZES(define_intypes)
 
 #define	NBBY		8	/* Number of bits per byte. */
 #ifdef __cplusplus

--- a/include/stdint.h
+++ b/include/stdint.h
@@ -41,6 +41,59 @@
 #ifndef _MACHINE__STDINT_H_
 #define	_MACHINE__STDINT_H_
 
+/*
+ * Useful integer type names that we can't pick up from the compile-time
+ * environment.
+ */
+typedef char		int8_t;
+typedef unsigned char	u_char;
+typedef unsigned char	uint8_t;
+typedef short		int16_t;
+typedef unsigned short	u_short;
+typedef unsigned short	uint16_t;
+typedef int		int32_t;
+typedef unsigned int	u_int;
+typedef unsigned int	uint32_t;
+typedef long		intmax_t;
+typedef long		quad_t;
+typedef long		ptrdiff_t;
+typedef long		int64_t;
+typedef unsigned long	u_long;
+typedef unsigned long	uint64_t;
+typedef	unsigned long	uintmax_t;
+typedef unsigned long	u_quad_t;
+typedef __uintcap_t	uintptr_t;
+//typedef unsigned long	uintptr_t;
+typedef __intcap_t	intptr_t;
+typedef unsigned long	caddr_t;
+
+typedef u_long		ulong;
+typedef u_char		uchar;
+typedef uint8_t		u8;
+typedef uint16_t	u16;
+typedef uint32_t	u32;
+typedef uint64_t	u64;
+typedef uint16_t	__u16;
+typedef uint32_t	__u32;
+typedef uint8_t		u_int8_t;
+typedef uint16_t	u_int16_t;
+typedef uint32_t	u_int32_t;
+typedef uint64_t	u_int64_t;
+
+#define define_intypes(size)                                \
+typedef int ## size ## _t  int_least ## size ## _t;         \
+typedef uint ## size ## _t  uint_least ## size ## _t;       \
+typedef int ## size ## _t  int_fast ## size ## _t;          \
+typedef uint ## size ## _t  uint_fast ## size ## _t;
+
+#define INT_SIZES(ITEM) ITEM(8) ITEM(16) ITEM(32) ITEM(64)
+
+INT_SIZES(define_intypes)
+
+#undef define_inttypes
+#undef INT_SIZES
+
+
 #if !defined(__cplusplus) || defined(__STDC_CONSTANT_MACROS)
 
 #define	INT8_C(c)		(c)

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -95,6 +95,9 @@ static inline void * calloc_debug(size_t n, size_t s) {
 void 	abort(void)      __dead2;
 void	exit(int status) __dead2;
 
+#define EXIT_SUCCESS 0
+#define EXIT_FAILURE 1
+
 char *  itoa ( int value, char * str, int base );
 int     atoi(const char* str);
 

--- a/include/string.h
+++ b/include/string.h
@@ -56,7 +56,7 @@ char *	strncpy(char * dest,const char *src,size_t count);
 char *  strstr(const char *s, const char *find);
 char *strpbrk(const char *str1, const char *str2);
 
-int memcmp ( const char * ptr1, const char * ptr2, size_t num );
+int memcmp ( const void * ptr1, const void * ptr2, size_t num );
 
 #define strcoll strcmp
 #define strxfrm strncpy

--- a/include/strings.h
+++ b/include/strings.h
@@ -28,43 +28,15 @@
  * SUCH DAMAGE.
  */
 
-#ifndef __STRING_H__
-#define	__STRING_H__
+#ifndef __STRINGS_H__
+#define	__STRINGS_H__
 
-#include "cdefs.h"
+#include <cdefs.h>
 #include "mips.h"
-#include "locale.h"
 
 __BEGIN_DECLS
-void *	memcpy(void *dest, const void *src, size_t n);
-void * memmove ( void * destination, const void * source, size_t num );
-void *	memset(void *, int, size_t);
-char *	strchr(const char * s, int c);
-char *  strrchr(const char *cp, int ch);
-char *	strcpy(char * dest,const char *src);
-char *  strcat ( char * destination, const char * source );
-char * strncat(char *dst, const char *src, size_t n);
-size_t strcspn(const char * __restrict s, const char * __restrict charset);
-size_t strspn(const char *s, const char *charset);
-char * strdup(const char *str1);
-void *  memchr( const void * ptr, int value, size_t num );
-int	strcmp(const char *s1, const char *s2);
-size_t	strlen(const char *str);
-int	strncmp(const char * cs,const char * ct,size_t count);
-char *	strncpy(char * dest,const char *src,size_t count);
-char *  strstr(const char *s, const char *find);
-char *strpbrk(const char *str1, const char *str2);
-
-int memcmp ( const void * ptr1, const void * ptr2, size_t num );
-
-#define strcoll strcmp
-#define strxfrm strncpy
-
-static char *strerror(__unused int errnum) {
-    // TODO: There are actually strings defined via macro in errno.h to use
-    return NULL;
-}
+void	bzero(void *, size_t);
 
 __END_DECLS
 
-#endif /* !__STRING_H__ */
+#endif /* !__STRINGS_H__ */

--- a/libcrt/crtbeginC.c
+++ b/libcrt/crtbeginC.c
@@ -31,6 +31,7 @@
 #include "mips.h"
 #include "cheric.h"
 #include "string.h"
+#include "strings.h"
 #include "dylink.h"
 #include "crt.h"
 

--- a/libuser/src/dedup.c
+++ b/libuser/src/dedup.c
@@ -39,6 +39,7 @@
 #include "nano/usernano.h"
 #include "stdlib.h"
 #include "crt.h"
+#include "strings.h"
 
 static act_kt dedup_service = NULL;
 

--- a/socket_test/src/main.c
+++ b/socket_test/src/main.c
@@ -34,6 +34,7 @@
 #include "assert.h"
 #include "stdio.h"
 #include "string.h"
+#include "strings.h"
 #include "capmalloc.h"
 
 #define DATA_SIZE 0x800

--- a/unaligned_test/src/main.c
+++ b/unaligned_test/src/main.c
@@ -31,6 +31,7 @@
 #include "cheric.h"
 #include "assert.h"
 #include "string.h"
+#include "strings.h"
 #include "stdio.h"
 
 int main(__unused register_t arg,__unused capability carg) {


### PR DESCRIPTION
While trying to build `mbedtls`, a number of errors were reported that ultimately stemmed from the standard headers not quite agreeing with the standard.

In one case, `mbedtls` `#define`-d `ADD` for its own EC math, which conflicted with the definition in `cheric.h`, which is basically globally in scope.