### PR TITLE
Combined REVOKE_TIME into REVOKE_BENCH

### DIFF
--- a/cherios/core/memmgt/include/mmap.h
+++ b/cherios/core/memmgt/include/mmap.h
@@ -44,7 +44,6 @@
 #define POOL_LARGE_THRESHOLD (1 << 26)
 
 #define REVOKE_BENCH 0
-#define REVOKE_TIME 0
 #define REVOKE_PRIO PRIO_IDLE
 
 // Measured in virtual pages

--- a/cherios/core/memmgt/src/mmap.c
+++ b/cherios/core/memmgt/src/mmap.c
@@ -1598,11 +1598,7 @@ void __revoke(void) {
 
 #if(REVOKE_BENCH)
     tracking.revokes_started ++;
-#endif
-
-#if (REVOKE_BENCH && REVOKE_TIME)
     uint64_t before, after;
-
     if(revoke_bench_act) before = syscall_now();
 #endif
 
@@ -1613,13 +1609,11 @@ void __revoke(void) {
     size_t length = nfo.length + RES_META_SIZE;
     tracking.revoked_bytes += length;
     tracking.revokes_finished ++;
-#if(REVOKE_TIME)
     if(revoke_bench_act) {
         after = syscall_now();
 
         message_send(scanned, length, after - before, 0, NULL, NULL, NULL, NULL, revoke_bench_act, SEND, 0);
     }
-#endif
 #endif
 
     if(!cheri_gettag(res)) {


### PR DESCRIPTION
Combining the two flags means that we always record timing when the benchmark is run.